### PR TITLE
fix: use --jsonUpgraded to only detect actual dependency updates

### DIFF
--- a/.github/workflows/dependency-bot.yml
+++ b/.github/workflows/dependency-bot.yml
@@ -44,9 +44,8 @@ jobs:
         id: check-updates
         run: |
           echo "🔍 Checking for dependency updates..."
-          
-          # Check what can be updated
-          ncu --jsonAll > updates.json
+            # Check what can be updated (only actual updates, not current versions)
+          ncu --jsonUpgraded > updates.json
           
           # Check if there are any updates available
           if [ "$(cat updates.json)" = "{}" ]; then


### PR DESCRIPTION
- Changed from ncu --jsonAll to ncu --jsonUpgraded
- This prevents creating PRs when there are no actual updates
- --jsonAll returns full package.json, --jsonUpgraded only returns actual updates
- Workflow will now correctly skip when all dependencies are up to date